### PR TITLE
Better error handling for url_download.py

### DIFF
--- a/processing/cuckoo/cuckoo.py
+++ b/processing/cuckoo/cuckoo.py
@@ -97,7 +97,7 @@ class Cuckoo(ProcessingModule):
         self.process_report()
 
         # Get back memory dump
-        # self.get_memory_dump()
+        self.get_memory_dump()
 
         # Add report URL to results
         self.results['URL'] = urljoin(self.web_endpoint, "/analysis/{}/summary/".format(self.task_id))
@@ -179,7 +179,10 @@ class Cuckoo(ProcessingModule):
 
     def get_memory_dump(self):
         url = urljoin(self.web_endpoint, '/full_memory/{0}/'.format(self.task_id))
-        response = requests.get(url, stream=True)
+        try:
+            response = requests.get(url, stream=True)
+        except requests.exceptions.RequestException, e:
+            return False
 
         self.register_response_as('memory_dump', response)
 

--- a/processing/cuckoo/cuckoo.py
+++ b/processing/cuckoo/cuckoo.py
@@ -97,7 +97,7 @@ class Cuckoo(ProcessingModule):
         self.process_report()
 
         # Get back memory dump
-        self.get_memory_dump()
+        # self.get_memory_dump()
 
         # Add report URL to results
         self.results['URL'] = urljoin(self.web_endpoint, "/analysis/{}/summary/".format(self.task_id))

--- a/processing/url_download.py
+++ b/processing/url_download.py
@@ -28,6 +28,9 @@ class URLDownload(ProcessingModule):
 
             filepath = os.path.join(tmpdir, filename)
 
+            if os.path.isdir(filepath):
+                raise ModuleExecutionError("Could not download file. Status: File not found.")
+
             with open(filepath, 'wb') as fd:
                 for chunk in response.iter_content(1024):
                     fd.write(chunk)

--- a/processing/url_download.py
+++ b/processing/url_download.py
@@ -17,7 +17,10 @@ class URLDownload(ProcessingModule):
     triggered_by = "!"
 
     def each(self, target):
-        response = requests.get(target, stream=True)
+        try:
+            response = requests.get(target, stream=True)
+        except requests.exceptions.RequestException, e:
+            raise ModuleExecutionError("Could not download file. Status: {}".format(e))
 
         if response.status_code == 200:
             tmpdir = tempdir()


### PR DESCRIPTION
1. Exceptions should be handled.
2. Only URL with file name should be processed.