### PR TITLE
peepdf Module : Fix a dependency conflict

### DIFF
--- a/processing/pdf/requirements.txt
+++ b/processing/pdf/requirements.txt
@@ -1,2 +1,1 @@
 peepdf==0.4.2
-jsbeautifier==1.13.0


### PR DESCRIPTION
peepdf already has a dependency `jsbeautifier==1.6.2`, which causes a dependency conflict.

This PR fixes the conflict by letting peepdf manage jsbeautifier