### PR TITLE
extract module: use HTTPS protocol instead of git protocol in the dockerfile

### DIFF
--- a/processing/extract/docker/Dockerfile
+++ b/processing/extract/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add libarchive-dev git
 
 
 # Install PyEasyArchive from CERT SG's fork (to manage encrypted files)
-RUN pip3 install git+git://github.com/certsocietegenerale/PyEasyArchive@f4f386ccb9552d58cab241fc16cc31a2b00a8341#egg=libarchive
+RUN pip3 install git+https://github.com/certsocietegenerale/PyEasyArchive@f4f386ccb9552d58cab241fc16cc31a2b00a8341#egg=libarchive
 
 
 COPY extract.py /


### PR DESCRIPTION
Build is failing because `The unauthenticated git protocol on port 9418 is no longer supported`