### PR TITLE
virustotal_download: Unlock requests requirements

### DIFF
--- a/preloading/virustotal_download/requirements.txt
+++ b/preloading/virustotal_download/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.24.0
+requests


### PR DESCRIPTION
let the main fame repository take care of the requests version. The version is already unlocked in several other modules (cuckoo, Joe)