### PR TITLE
apk, ratdecoders modules: force pycryptodome as dependency instead of the old PyCrypto

### DIFF
--- a/processing/apk/apk_plugins/thoughtcrime.py
+++ b/processing/apk/apk_plugins/thoughtcrime.py
@@ -7,7 +7,7 @@ from . import APKPlugin
 try:
     from Crypto.Cipher import Blowfish
     HAVE_PYCRYPTO = True
-except ImportError:
+except (ImportError, NameError):
     HAVE_PYCRYPTO = False
 
 

--- a/processing/apk/requirements.txt
+++ b/processing/apk/requirements.txt
@@ -1,3 +1,4 @@
 androguard==3.3.5
 yara-python==4.0.2
 pyelftools==0.26
+pycryptodome

--- a/processing/ratdecoders/ratdecoders.py
+++ b/processing/ratdecoders/ratdecoders.py
@@ -9,7 +9,7 @@ try:
     from malwareconfig.modules import __decoders__, __preprocessors__
 
     HAVE_RATDECODERS = True
-except ImportError:
+except (ImportError, NameError):
     HAVE_RATDECODERS = False
 
 

--- a/processing/ratdecoders/requirements.txt
+++ b/processing/ratdecoders/requirements.txt
@@ -1,2 +1,3 @@
 yara-python==4.0.2
 malwareconfig==1.0.4
+pycryptodome


### PR DESCRIPTION
Latest version of ```malwareconfig``` (a dependency required for module ratdecoders) stil include ```pycrypto``` as requirement, instead  of ```pycryptodome```.

This PR force the installation of pycryptodome in addition to pycrypto. This should fix most pycrypto related errors (```NameError: name 'xrange' is not defined```, etc..)