### PR TITLE
apk_verification module: use playstoreapi instead of googleplay-api

### DIFF
--- a/processing/apk_verification/apk_verification.py
+++ b/processing/apk_verification/apk_verification.py
@@ -13,7 +13,7 @@ except ImportError:
     HAVE_ANDROGUARD = False
 
 try:
-    from googleplay_api.googleplay import GooglePlayAPI
+    from playstoreapi.googleplay import GooglePlayAPI
     HAVE_GOOGLEPLAY = True
 except ImportError:
     HAVE_GOOGLEPLAY = False
@@ -47,7 +47,7 @@ class APKVerification(ProcessingModule):
             raise ModuleInitializationError(self, "Missing dependency: androguard")
 
         if not HAVE_GOOGLEPLAY:
-            raise ModuleInitializationError(self, "Missing dependency: googleplay-api")
+            raise ModuleInitializationError(self, "Missing dependency: playstore-api")
 
     def validate_signature(self, file, key='target'):
         # Verify the signature

--- a/processing/apk_verification/requirements.txt
+++ b/processing/apk_verification/requirements.txt
@@ -1,2 +1,2 @@
 androguard
-googleplay-api
+playstoreapi


### PR DESCRIPTION
This module is currently failing to load on recent python versions, with error ```Descriptors cannot not be created directly```.

Using ```playstoreapi``` instead of ```googleplay-api``` fixes the issue. Hence this PR