### PR TITLE
document_preview, joe modules: fix output encoding

### DIFF
--- a/processing/document_preview/document_preview.py
+++ b/processing/document_preview/document_preview.py
@@ -68,7 +68,7 @@ class DocumentPreview(ProcessingModule):
             volumes={self.outdir: {'bind': '/data', 'mode': 'rw'}},
             stderr=True,
             remove=True
-        )
+        ).decode().strip()
 
     def each_with_type(self, target, target_type):
         self.results = ""
@@ -80,7 +80,8 @@ class DocumentPreview(ProcessingModule):
         output = self.preview(target, target_type)
 
         # save log output from dockerized app
-        self.save_output(output)
+        if output:
+            self.save_output(output)
 
         # output dir
         results_dir = os.path.join(self.outdir, 'output')

--- a/processing/joe/joe.py
+++ b/processing/joe/joe.py
@@ -268,5 +268,5 @@ class Joe(ProcessingModule):
         graph = report.find(id='behaviorGraph')
         if graph is not None:
             graph = graph.find('svg')
-            self.results['graph'] = graph.encode('utf8')
+            self.results['graph'] = str(graph)
 


### PR DESCRIPTION
These two modules are currently printing some `b''` in their logs/output. 
This is probably some leftover from the python3 migration.