### PR TITLE
`extract` module: Handle errors when dealing with unicode filenames

### DIFF
--- a/processing/extract/docker/extract.py
+++ b/processing/extract/docker/extract.py
@@ -32,7 +32,7 @@ try:
         for entry in ar:
             if entry.filetype.IFREG:
                 entries.append(entry.pathname)
-except libarchive.exception.ArchiveError:
+except (libarchive.exception.ArchiveError, UnicodeEncodeError, UnicodeDecodeError):
     print("Cannot read archive content")
 
 should_extract = len(entries) <= maximum_extracted_files


### PR DESCRIPTION
Fix #75