### PR TITLE
document_preview - change names of output images to be compliant with…

### DIFF
--- a/processing/document_preview/docker/requirements.txt
+++ b/processing/document_preview/docker/requirements.txt
@@ -1,2 +1,3 @@
 pdf2image==1.16.0
 Pillow==9.3.0
+Werkzeug==2.2.3

--- a/processing/document_preview/docker/requirements.txt
+++ b/processing/document_preview/docker/requirements.txt
@@ -1,3 +1,2 @@
 pdf2image==1.16.0
 Pillow==9.3.0
-Werkzeug==2.2.3

--- a/processing/document_preview/docker/script.py
+++ b/processing/document_preview/docker/script.py
@@ -2,6 +2,7 @@ import argparse
 import os
 from pdf2image import convert_from_path
 import re
+from werkzeug.utils import secure_filename
 
 
 def pdftoimages(target, max_pages):
@@ -18,7 +19,9 @@ def pdftoimages(target, max_pages):
     # save pages to jpeg format
     for page in pages:
         counter = counter + 1
-        page.save('./output/{}_{}.jpeg'.format(re.sub('[^A-Za-z0-9]+', '_', target), counter))
+        filename_base = '{}'.format(re.sub('[^A-Za-z0-9]+', '_', target))
+        secure_filename_base = secure_filename(filename_base)
+        page.save('./output/{}_{}.jpeg'.format(secure_filename_base, counter))
 
     if counter == 0:
         print('error: could not convert PDF to images')

--- a/processing/document_preview/docker/script.py
+++ b/processing/document_preview/docker/script.py
@@ -2,7 +2,6 @@ import argparse
 import os
 from pdf2image import convert_from_path
 import re
-from werkzeug.utils import secure_filename
 
 
 def pdftoimages(target, max_pages):
@@ -19,9 +18,7 @@ def pdftoimages(target, max_pages):
     # save pages to jpeg format
     for page in pages:
         counter = counter + 1
-        filename_base = '{}'.format(re.sub('[^A-Za-z0-9]+', '_', target))
-        secure_filename_base = secure_filename(filename_base)
-        page.save('./output/{}_{}.jpeg'.format(secure_filename_base, counter))
+        page.save('./output/output_{}.jpeg'.format(counter))
 
     if counter == 0:
         print('error: could not convert PDF to images')


### PR DESCRIPTION
… werkzeug secure_filename used in fame core view/analysis.

Bug corrected : In local setup, when document_preview was launched on PDF files with name such as _my pdf_example.pdf, names of images generated were not compliant with werkzeug secure_filename method. As a consequence, the core view part of fame was trying to retrieve images with a different name, which did not exist (the first _ was removed in this example.)