### PR TITLE
exiftool, detect_it_easy modules: better handle docker daemon errors

### DIFF
--- a/processing/detect_it_easy/detect_it_easy.py
+++ b/processing/detect_it_easy/detect_it_easy.py
@@ -26,7 +26,10 @@ class DetectItEasy(ProcessingModule):
                 )
             )
         except (docker.errors.ContainerError, docker.errors.APIError) as e:
-            self.parse_output(e.stderr)
+            if hasattr(e, 'stderr'):
+                self.log('error', e.stderr)
+            elif hasattr(e, 'explanation'):
+                self.log('error', e.explanation)
 
     def parse_output(self, out):
         out = out.decode("utf-8", errors="replace")

--- a/processing/exiftool/exiftool.py
+++ b/processing/exiftool/exiftool.py
@@ -45,7 +45,10 @@ File Permissions""",
                 stderr=True,
                 remove=True))
         except (docker.errors.ContainerError, docker.errors.APIError) as e:
-            self.parse_output(e.stderr)
+            if hasattr(e, 'stderr'):
+                self.log('error', e.stderr)
+            elif hasattr(e, 'explanation'):
+                self.log('error', e.explanation)
 
     def parse_output(self, out):
         out = out.decode('utf-8', errors='replace')


### PR DESCRIPTION
These two modules currently throw an error upon docker failure

```
  File "/data/fame/fame/modules/community/processing/exiftool/exiftool.py", line 48, in exiftool
    self.parse_output(e.stderr)
                      ^^^^^^^^
AttributeError: 'APIError' object has no attribute 'stderr'
```