### PR TITLE
`lookyloo` module: make sure redirects exists

### DIFF
--- a/processing/lookyloo/lookyloo.py
+++ b/processing/lookyloo/lookyloo.py
@@ -130,7 +130,8 @@ class Lookyloo(ProcessingModule):
         for redirect in redirects["response"]["redirects"]:
             self.results["redirections"].append(redirect)
 
-        self.results["target"] = redirects["response"]["redirects"][-1]
+        if redirects["response"]["redirects"]:
+            self.results["target"] = redirects["response"]["redirects"][-1]
 
         screenshot = myinstance.get_screenshot(uuid)
 


### PR DESCRIPTION
URLs sometimes have no redirect, causing the module to crash