### PR TITLE
Defang python package replacement and new defang option using mattermost code block

### DIFF
--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -59,15 +59,15 @@ class Mattermost(ReportingModule):
 
         def defangs(var):
             if self.defang:
-                if type(var) is list:
-                    var = list(map(defang, var))
-                else:
+                if isinstance(var, str):
                     var = defang(var)
-            if self.code:
-                if type(var) is list:
-                    var = list(map(lambda s : '`' + s + '`', var))
                 else:
+                    var = list(map(defang, var))
+            if self.code:
+                if isinstance(var, str):
                     var = '`' + var + '`'
+                else:
+                    var = list(map(lambda s : '`' + s + '`', var))
             return var
 
         string = "Just finished analysis on {0}\n".format(", ".join(defangs(analysis._file["names"])))

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -44,9 +44,7 @@ class Mattermost(ReportingModule):
             return False
 
     def done(self, analysis):
-        string = "Just finished analysis on `{0}`\n".format(
-            defang(", ".join(analysis._file["names"]))
-        )
+        string = "Just finished analysis on `{0}`\n".format(", ".join(analysis._file["names"]))
 
         if analysis["modules"]:
             string += "Selected Modules: {}\n".format(', '.join(analysis['modules']))
@@ -64,7 +62,7 @@ class Mattermost(ReportingModule):
             string += "|:-----------|:-----|\n"
 
             for ioc in analysis["iocs"]:
-                string += "|`{}`|{}|\n".format(defang(ioc['value']), ', '.join(ioc['tags']))
+                string += "|`{}`|{}|\n".format(ioc['value'], ', '.join(ioc['tags']))
 
         string += "\n| Module | Status |\n"
         string += "|:-------|:------:|\n"

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -44,7 +44,7 @@ class Mattermost(ReportingModule):
             return False
 
     def done(self, analysis):
-        string = "Just finished analysis on {0}\n".format(
+        string = "Just finished analysis on `{0}`\n".format(
             defang(", ".join(analysis._file["names"]))
         )
 
@@ -64,7 +64,7 @@ class Mattermost(ReportingModule):
             string += "|:-----------|:-----|\n"
 
             for ioc in analysis["iocs"]:
-                string += "|{}|{}|\n".format(defang(ioc['value']), ', '.join(ioc['tags']))
+                string += "|`{}`|{}|\n".format(defang(ioc['value']), ', '.join(ioc['tags']))
 
         string += "\n| Module | Status |\n"
         string += "|:-------|:------:|\n"

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -28,7 +28,13 @@ class Mattermost(ReportingModule):
             "name": "fame_base_url",
             "type": "str",
             "description": "Base URL of your FAME instance, as you want it to appear in links.",
-        },
+            },
+        {
+            "name": "defang",
+            "type": "bool",
+            "default": "true",
+            "description": "Uncheck if you don't want to defang observables",
+        }
     ]
 
     def initialize(self):

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -59,7 +59,7 @@ class Mattermost(ReportingModule):
         submitted = str(analysis._file["names"])
 
         if self.defang:
-            submitted = defang(analysis._file["names"])
+            submitted = defang(submitted)
 
         if self.code:
             submitted = '`' + submitted + '`'

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -64,11 +64,7 @@ class Mattermost(ReportingModule):
         return myList
 
     def done(self, analysis):
-        submitted = analysis._file["names"]
-        iocs = analysis["iocs"]
-        cleanList(submitted) 
-        cleanList(iocs)
-        string = "Just finished analysis on {0}\n".format(", ".join(submitted))
+        string = "Just finished analysis on {0}\n".format(", ".join(cleanList(analysis._file["names"])))
 
         if analysis["modules"]:
             string += "Selected Modules: {}\n".format(', '.join(analysis['modules']))
@@ -86,7 +82,8 @@ class Mattermost(ReportingModule):
             string += "|:-----------|:-----|\n"
 
             for ioc in analysis["iocs"]:
-                string += "|{}|{}|\n".format(ioc['value'], ', '.join(ioc['tags']))
+                cleanList(ioc['value'])
+                string += "|{}|{}|\n".format(cleanList(ioc['value']), ', '.join(ioc['tags']))
 
         string += "\n| Module | Status |\n"
         string += "|:-------|:------:|\n"

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -33,13 +33,13 @@ class Mattermost(ReportingModule):
             "name": "defang",
             "type": "bool",
             "default": "true",
-            "description": "check if you want to defang observables",
+            "description": "check this box if you want to defang observables",
         },
         {
             "name": "code",
             "type": "bool",
             "default": "true",
-            "description": "check if you  want to set observables as inline code, no emoji interpretation and no url links",
+            "description": "check this box if you want to write observables as inline code, you will not have any emoji interpretation or URL links",
         }
     ]
 
@@ -55,15 +55,19 @@ class Mattermost(ReportingModule):
         else:
             return False
 
-    def done(self, analysis):
-        submitted = analysis._file["names"]
-
+    def cleanList(myList):
         if self.defang:
-            submitted = list(map(defang, submitted))
+            myList = list(map(defang, myList))
 
         if self.code:
-            submitted = list(map(lambda s : '`' + s + '`', submitted))
+            myList = list(map(lambda s : '`' + s + '`', myList))
+        return myList
 
+    def done(self, analysis):
+        submitted = analysis._file["names"]
+        iocs = analysis["iocs"]
+        cleanList(submitted) 
+        cleanList(iocs)
         string = "Just finished analysis on {0}\n".format(", ".join(submitted))
 
         if analysis["modules"]:

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -57,13 +57,18 @@ class Mattermost(ReportingModule):
 
     def done(self, analysis):
 
-        def defangs(myList):
+        def defangs(var):
             if self.defang:
-                myList = list(map(defang, myList))
-
+                if type(var) is list:
+                    var = list(map(defang, var))
+                else:
+                    var = defang(var)
             if self.code:
-                myList = list(map(lambda s : '`' + s + '`', myList))
-            return myList
+                if type(var) is list:
+                    var = list(map(lambda s : '`' + s + '`', var))
+                else:
+                    var = '`' + var + '`'
+            return var
 
         string = "Just finished analysis on {0}\n".format(", ".join(defangs(analysis._file["names"])))
 

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -61,12 +61,12 @@ class Mattermost(ReportingModule):
             if self.defang:
                 if isinstance(var, str):
                     var = defang(var)
-                else:
+                if isinstance(var, list):
                     var = list(map(defang, var))
             if self.code:
                 if isinstance(var, str):
                     var = '`' + var + '`'
-                else:
+                if isinstance(var, list):
                     var = list(map(lambda s : '`' + s + '`', var))
             return var
 

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -33,7 +33,13 @@ class Mattermost(ReportingModule):
             "name": "defang",
             "type": "bool",
             "default": "true",
-            "description": "Uncheck if you don't want to defang observables",
+            "description": "check if you want to defang observables",
+        },
+        {
+            "name": "code",
+            "type": "bool",
+            "default": "true",
+            "description": "check if you  want to set observables as inline code, no emoji interpretation and no url links",
         }
     ]
 
@@ -50,7 +56,15 @@ class Mattermost(ReportingModule):
             return False
 
     def done(self, analysis):
-        string = "Just finished analysis on `{0}`\n".format(", ".join(analysis._file["names"]))
+        submitted = analysis._file["names"]
+
+        if self.defang:
+            submitted = defang(analysis._file["names"])
+
+        if self.code:
+            submitted = str('`', submitted, '`')
+
+        string = "Just finished analysis on `{0}`\n".format(", ".join(submitted))
 
         if analysis["modules"]:
             string += "Selected Modules: {}\n".format(', '.join(analysis['modules']))

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -39,7 +39,7 @@ class Mattermost(ReportingModule):
             "name": "code",
             "type": "bool",
             "default": "true",
-            "description": "check if you want to set observables as inline code, no emoji interpretation and no url links",
+            "description": "check if you  want to set observables as inline code, no emoji interpretation and no url links",
         }
     ]
 
@@ -56,15 +56,15 @@ class Mattermost(ReportingModule):
             return False
 
     def done(self, analysis):
-        submitted = analysis._file["names"]
+        submitted = str(analysis._file["names"])
 
         if self.defang:
             submitted = defang(analysis._file["names"])
 
         if self.code:
             submitted = '`' + submitted + '`'
-
-        string = "Just finished analysis on {0}\n".format(", ".join(submitted))
+        
+        string = "Just finished analysis on `{0}`\n".format(", ".join(submitted))
 
         if analysis["modules"]:
             string += "Selected Modules: {}\n".format(', '.join(analysis['modules']))
@@ -82,7 +82,7 @@ class Mattermost(ReportingModule):
             string += "|:-----------|:-----|\n"
 
             for ioc in analysis["iocs"]:
-                string += "|{}|{}|\n".format(ioc['value'], ', '.join(ioc['tags']))
+                string += "|`{}`|{}|\n".format(ioc['value'], ', '.join(ioc['tags']))
 
         string += "\n| Module | Status |\n"
         string += "|:-------|:------:|\n"

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -55,16 +55,17 @@ class Mattermost(ReportingModule):
         else:
             return False
 
-    def cleanList(myList):
-        if self.defang:
-            myList = list(map(defang, myList))
-
-        if self.code:
-            myList = list(map(lambda s : '`' + s + '`', myList))
-        return myList
-
     def done(self, analysis):
-        string = "Just finished analysis on {0}\n".format(", ".join(cleanList(analysis._file["names"])))
+
+        def defangs(myList):
+            if self.defang:
+                myList = list(map(defang, myList))
+
+            if self.code:
+                myList = list(map(lambda s : '`' + s + '`', myList))
+            return myList
+
+        string = "Just finished analysis on {0}\n".format(", ".join(defangs(analysis._file["names"])))
 
         if analysis["modules"]:
             string += "Selected Modules: {}\n".format(', '.join(analysis['modules']))
@@ -82,8 +83,7 @@ class Mattermost(ReportingModule):
             string += "|:-----------|:-----|\n"
 
             for ioc in analysis["iocs"]:
-                cleanList(ioc['value'])
-                string += "|{}|{}|\n".format(cleanList(ioc['value']), ', '.join(ioc['tags']))
+                string += "|{}|{}|\n".format(defangs(ioc['value']), ', '.join(ioc['tags']))
 
         string += "\n| Module | Status |\n"
         string += "|:-------|:------:|\n"

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -57,13 +57,12 @@ class Mattermost(ReportingModule):
 
     def done(self, analysis):
         submitted = analysis._file["names"]
-
+        print(type(analysis._file["names"]))
         if self.defang:
             submitted = defang(submitted)
-
         if self.code:
             submitted = '`' + submitted + '`'
-        
+
         string = "Just finished analysis on {0}\n".format(", ".join(submitted))
 
         if analysis["modules"]:

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -56,7 +56,7 @@ class Mattermost(ReportingModule):
             return False
 
     def done(self, analysis):
-        submitted = str(analysis._file["names"])
+        submitted = analysis._file["names"]
 
         if self.defang:
             submitted = defang(submitted)
@@ -82,7 +82,7 @@ class Mattermost(ReportingModule):
             string += "|:-----------|:-----|\n"
 
             for ioc in analysis["iocs"]:
-                string += "|`{}`|{}|\n".format(ioc['value'], ', '.join(ioc['tags']))
+                string += "|{}|{}|\n".format(ioc['value'], ', '.join(ioc['tags']))
 
         string += "\n| Module | Status |\n"
         string += "|:-------|:------:|\n"

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -30,16 +30,16 @@ class Mattermost(ReportingModule):
             "description": "Base URL of your FAME instance, as you want it to appear in links.",
             },
         {
-            "name": "defang",
+            "name": "defangReplace",
             "type": "bool",
             "default": "true",
-            "description": "check this box if you want to defang observables",
+            "description": "check this box if you want to defang observables using replacement. example : http is replaced by hxxp",
         },
         {
-            "name": "code",
+            "name": "defangCode",
             "type": "bool",
             "default": "true",
-            "description": "check this box if you want to write observables as inline code, you will not have any emoji interpretation or URL links",
+            "description": "check this box if you want to defang observables using inline code, it avoids to have interpretation like emojis and URL links",
         }
     ]
 
@@ -58,12 +58,12 @@ class Mattermost(ReportingModule):
     def done(self, analysis):
 
         def defangs(var):
-            if self.defang:
+            if self.defangReplace:
                 if isinstance(var, str):
                     var = defang(var)
                 if isinstance(var, list):
                     var = list(map(defang, var))
-            if self.code:
+            if self.defangCode:
                 if isinstance(var, str):
                     var = '`' + var + '`'
                 if isinstance(var, list):

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -64,7 +64,7 @@ class Mattermost(ReportingModule):
         if self.code:
             submitted = '`' + submitted + '`'
         
-        string = "Just finished analysis on `{0}`\n".format(", ".join(submitted))
+        string = "Just finished analysis on {0}\n".format(", ".join(submitted))
 
         if analysis["modules"]:
             string += "Selected Modules: {}\n".format(', '.join(analysis['modules']))

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -57,11 +57,12 @@ class Mattermost(ReportingModule):
 
     def done(self, analysis):
         submitted = analysis._file["names"]
-        print(type(analysis._file["names"]))
+
         if self.defang:
-            submitted = defang(submitted)
+            submitted = list(map(defang, submitted))
+
         if self.code:
-            submitted = '`' + submitted + '`'
+            submitted = list(map(lambda s : '`' + s + '`', submitted))
 
         string = "Just finished analysis on {0}\n".format(", ".join(submitted))
 

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -64,7 +64,7 @@ class Mattermost(ReportingModule):
         if self.code:
             submitted = str('`', submitted, '`')
 
-        string = "Just finished analysis on `{0}`\n".format(", ".join(submitted))
+        string = "Just finished analysis on {0}\n".format(", ".join(submitted))
 
         if analysis["modules"]:
             string += "Selected Modules: {}\n".format(', '.join(analysis['modules']))
@@ -82,7 +82,7 @@ class Mattermost(ReportingModule):
             string += "|:-----------|:-----|\n"
 
             for ioc in analysis["iocs"]:
-                string += "|`{}`|{}|\n".format(ioc['value'], ', '.join(ioc['tags']))
+                string += "|{}|{}|\n".format(ioc['value'], ', '.join(ioc['tags']))
 
         string += "\n| Module | Status |\n"
         string += "|:-------|:------:|\n"

--- a/reporting/mattermost.py
+++ b/reporting/mattermost.py
@@ -39,7 +39,7 @@ class Mattermost(ReportingModule):
             "name": "code",
             "type": "bool",
             "default": "true",
-            "description": "check if you  want to set observables as inline code, no emoji interpretation and no url links",
+            "description": "check if you want to set observables as inline code, no emoji interpretation and no url links",
         }
     ]
 
@@ -62,7 +62,7 @@ class Mattermost(ReportingModule):
             submitted = defang(analysis._file["names"])
 
         if self.code:
-            submitted = str('`', submitted, '`')
+            submitted = '`' + submitted + '`'
 
         string = "Just finished analysis on {0}\n".format(", ".join(submitted))
 

--- a/reporting/requirements.txt
+++ b/reporting/requirements.txt
@@ -1,1 +1,1 @@
-defang==0.5.3
+pydefang==0.0.1


### PR DESCRIPTION
For the mattermost reporting module:
- replace the python packages defang by pydefang for mattermost to avoid defang issues with nested URLs.
- add a new options to defang URLs, the usage of mattermost code blocks 
