### PR TITLE
`msg` module: Extract nested msg files

### DIFF
--- a/processing/msg_extractor/msg_extractor.py
+++ b/processing/msg_extractor/msg_extractor.py
@@ -38,17 +38,17 @@ class MSG(ProcessingModule):
                 try:
                     attachment.save(customPath=outdir, useMsgFilename=True)
                 except (extract_msg.exceptions.DataNotFoundError, AttributeError):
-                    continue
+                    pass
+                else:
+                    folder = os.path.splitext(os.path.split(attachment.data.filename)[1])[0]
+                    folder = msg_utils.prepareFilename(folder)[:256]
+                    for file in os.listdir("%s%s%s" % (outdir, os.path.sep, folder)):
+                        paths.append("%s%s%s%s%s" % (outdir, os.path.sep, folder, os.path.sep, file))
 
-                folder = os.path.splitext(os.path.split(attachment.data.filename)[1])[0]
-                folder = msg_utils.prepareFilename(folder)[:256]
-                for file in os.listdir("%s%s%s" % (outdir, os.path.sep, folder)):
-                    paths.append("%s%s%s%s%s" % (outdir, os.path.sep, folder, os.path.sep, file))
-            else:
-                attachment.save(customPath=outdir)
+            attachment.save(customPath=outdir, extractEmbedded=True)
 
-                filename = msg_utils.inputToString(attachment.getFilename(), attachment.msg.stringEncoding)
-                paths.append("%s%s%s" % (outdir, os.path.sep, msg_utils.prepareFilename(filename)))
+            filename = msg_utils.inputToString(attachment.getFilename(), attachment.msg.stringEncoding)
+            paths.append("%s%s%s" % (outdir, os.path.sep, msg_utils.prepareFilename(filename)))
         return paths
 
     def extract_urls(self, mail):

--- a/processing/msg_extractor/requirements.txt
+++ b/processing/msg_extractor/requirements.txt
@@ -1,1 +1,1 @@
-extract-msg==0.36.1
+extract-msg==0.49.0


### PR DESCRIPTION
The MSG module currently does not extract nested `.msg` files

This was originally due to a limitation of msg-extractor (https://github.com/TeamMsgExtractor/msg-extractor/issues/117), which has since been corrected.

This PR reflect msg-extractor changes and allow saving nested `.msg` files as attachment