### PR TITLE
update exif version

### DIFF
--- a/processing/exiftool/docker/Dockerfile
+++ b/processing/exiftool/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3
 
-ENV EXIFTOOL_VERSION=12.76
+ENV EXIFTOOL_VERSION=13.17
 
 RUN apk add --no-cache perl perl-utils make
 


### PR DESCRIPTION
docker build error for version 12.76, which is no longer hosted at https://exiftool.org/Image-ExifTool-12.76.tar.gz. updating to 13.17 allows successful build of docker image and test of the exiftool module in fame was successful.

```bash
#7 [4/5] RUN wget https://exiftool.org/Image-ExifTool-12.76.tar.gz     && tar -zxvf Image-ExifTool-12.76.tar.gz     && cd Image-ExifTool-12.76     && perl Makefile.PL     && make test     && make install     && cd ..     && rm -rf Image-ExifTool-12.76
#7 0.482 Connecting to exiftool.org (69.163.182.10:443)
#7 1.124 wget: server returned error: HTTP/1.1 404 Not Found
#7 ERROR: process "/bin/sh -c wget https://exiftool.org/Image-ExifTool-${EXIFTOOL_VERSION}.tar.gz     && tar -zxvf Image-ExifTool-${EXIFTOOL_VERSION}.tar.gz     && cd Image-ExifTool-${EXIFTOOL_VERSION}     && perl Makefile.PL     && make test     && make install     && cd ..     && rm -rf Image-ExifTool-${EXIFTOOL_VERSION}" did not complete successfully: exit code: 1
------
 > [4/5] RUN wget https://exiftool.org/Image-ExifTool-12.76.tar.gz     && tar -zxvf Image-ExifTool-12.76.tar.gz     && cd Image-ExifTool-12.76     && perl Makefile.PL     && make test     && make install     && cd ..     && rm -rf Image-ExifTool-12.76:
0.482 Connecting to exiftool.org (69.163.182.10:443)
1.124 wget: server returned error: HTTP/1.1 404 Not Found
------
Dockerfile:11
--------------------
  10 |     # Download and install exiftool
  11 | >>> RUN wget https://exiftool.org/Image-ExifTool-${EXIFTOOL_VERSION}.tar.gz \
  12 | >>>     && tar -zxvf Image-ExifTool-${EXIFTOOL_VERSION}.tar.gz \
  13 | >>>     && cd Image-ExifTool-${EXIFTOOL_VERSION} \
  14 | >>>     && perl Makefile.PL \
  15 | >>>     && make test \
  16 | >>>     && make install \
  17 | >>>     && cd .. \
  18 | >>>     && rm -rf Image-ExifTool-${EXIFTOOL_VERSION}
  19 |
--------------------
ERROR: failed to solve: process "/bin/sh -c wget https://exiftool.org/Image-ExifTool-${EXIFTOOL_VERSION}.tar.gz     && tar -zxvf Image-ExifTool-${EXIFTOOL_VERSION}.tar.gz     && cd Image-ExifTool-${EXIFTOOL_VERSION}     && perl Makefile.PL     && make test     && make install     && cd ..     && rm -rf Image-ExifTool-${EXIFTOOL_VERSION}" did not complete successfully: exit code: 1
```