### PR TITLE
Make FAME modules compatible with debian trixie

### DIFF
--- a/processing/apk/apk_plugins/z3core.py
+++ b/processing/apk/apk_plugins/z3core.py
@@ -61,7 +61,7 @@ class Z3Core(APKPlugin):
                     continue
                 dll_data = data[symbol['st_value']:symbol['st_value'] + symbol['st_size']]
                 dll_data = gzip.GzipFile(fileobj=BytesIO(dll_data)).read()
-                regexp = """rule find_url {
+                regexp = r"""rule find_url {
                             strings:
                             $url = /http:\/\/[A-Za-z0-9\.\/$\-_+!\*'(),]*/ wide
                             condition:

--- a/processing/document_preview/document_preview.py
+++ b/processing/document_preview/document_preview.py
@@ -13,7 +13,7 @@ def atoi(text):
 
 # Correctly sort pages
 def natural_keys(text):
-    return [atoi(c) for c in re.split('(\d+)', text)]
+    return [atoi(c) for c in re.split(r'(\d+)', text)]
 
 
 class DocumentPreview(ProcessingModule):

--- a/processing/email_headers/email_headers.py
+++ b/processing/email_headers/email_headers.py
@@ -91,7 +91,7 @@ class EmailHeader(ProcessingModule):
         # if the fuzzy parser failed to parse the line due to
         # incorrect timezone information issue 5 GitHub
         except (ValueError, dateutil.parser._parser.ParserError):
-            for regex in ["^(.*?)\s*\(", "\s*?(.+) UTC", "by.+\)\s(.+)"]:
+            for regex in [r"^(.*?)\s*\(", r"\s*?(.+) UTC", r"by.+\)\s(.+)"]:
                 r = re.findall(regex, line)
                 if r:
                     try:
@@ -120,7 +120,7 @@ class EmailHeader(ProcessingModule):
 
                 if line[0].startswith("from"):
                     data = re.findall(
-                        """
+                        r"""
                         from\s+
                         (.*?)\s+
                         by(.*?)

--- a/processing/flare_capa/requirements.txt
+++ b/processing/flare_capa/requirements.txt
@@ -1,1 +1,1 @@
-flare-capa==5.1.0
+flare-capa==9.2.1

--- a/processing/lookyloo/lookyloo.py
+++ b/processing/lookyloo/lookyloo.py
@@ -96,7 +96,7 @@ class Lookyloo(ProcessingModule):
 
         if self.safe_domains is not None:
             for safe_domain in self.safe_domains.split('\n'):
-                if re.match(".*\." + safe_domain.strip().lower() + "$", o.hostname):
+                if re.match(r".*\." + safe_domain.strip().lower() + "$", o.hostname):
                     self.log("info", "You must not analyze this domain. Did you read the documentation?")
                     self.results["redirections"].append(target)
                     self.results["target"] = "You must not analyze this domain. Did you read the documentation?"

--- a/processing/url_download.py
+++ b/processing/url_download.py
@@ -1,6 +1,6 @@
 import os
 import requests
-from cgi import parse_header
+from email.message import EmailMessage
 
 from fame.core.module import ProcessingModule
 from fame.common.utils import tempdir, sanitize_filename
@@ -25,11 +25,14 @@ class URLDownload(ProcessingModule):
 
         if response.status_code == 200:
             tmpdir = tempdir()
-            try:
-                filename = parse_header(response.headers['content-disposition'])[1]['filename']
-            except KeyError:
-                filename = target.split('/')[-1]
+            # Recommended way to get filename from headers
+            # https://peps.python.org/pep-0594/#cgi
+            msg = EmailMessage()
+            msg["Content-Disposition"] = response.headers.get("Content-Disposition")
+            filename = msg.get_filename()
 
+            if not filename:
+                filename = target.split('/')[-1]
             if not filename:
                 filename = "no_filename"
 

--- a/threat_intelligence/urlhaus/urlhaus.py
+++ b/threat_intelligence/urlhaus/urlhaus.py
@@ -36,7 +36,7 @@ class Urlhaus(ThreatIntelligenceModule):
         {
             'name': 'url_regex',
             'type': 'str',
-            'default': '(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9]\.[^\s]{2,})',
+            'default': r'(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9]\.[^\s]{2,})',
             'description': 'Regex rule for URL matching'
         },
     ]

--- a/virtualization/kvm/requirements.txt
+++ b/virtualization/kvm/requirements.txt
@@ -1,1 +1,1 @@
-libvirt-python==9.4.0
+libvirt-python==11.6.0


### PR DESCRIPTION
one module, `stringsifter`, is still not compatible with python 3.12 (and therefore debian trixie)

This is due to http://github.com/mandiant/stringsifter not being ported yet.